### PR TITLE
Run build on PR (but do not push)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,11 +18,10 @@ jobs:
           distribution: zulu
           java-version: 8
       -
-        name: Setup Gradle
+        name: Gradle build
         uses: gradle/gradle-build-action@v2
-      -
-        name: Execute Gradle build
-        run: ./gradlew build
+        with:
+          arguments: build
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -3,6 +3,8 @@ name: ci
 on:
   push:
     branches: master
+  pull-request:
+    branches: master
 
 jobs:
   main:
@@ -29,6 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
+        if: github.event_name == 'push'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
@@ -39,7 +42,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: acasal/cam2mqtt:latest
       -


### PR DESCRIPTION
This lets incoming PRs be checked for compilation errors.

Additionally this makes it easier to check the build with `act`: `act pull-request` will run without push/login, and thus will not need secrets.

As an extra: improved build caching by running build inside gradle action
