### PR TITLE
Onvif: added option to force debounce of motion events

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -21,6 +21,7 @@ cameras:
         monitor_events: true
         prefer_webhook_subscription: false
         # motion_debounce: true
+        # force_motion_debounce_time: 2 seconds # send motion=off after this time if camera does not report any other motion event
       reolink:
         # port: 443 # optional. 443/HTTPS by default
         # username: bob # optional. Alternative username for Reolink API

--- a/src/main/scala/camera/Protocol.scala
+++ b/src/main/scala/camera/Protocol.scala
@@ -9,6 +9,8 @@ import camera.modules.generic.GenericMqttCamModule
 import camera.modules.onvif.OnvifModule
 import camera.modules.reolink.{AiDetectionMode, ReolinkModule}
 
+import scala.concurrent.duration.FiniteDuration
+
 object CameraManProtocol {
 
     sealed trait CameraManCmd
@@ -114,7 +116,8 @@ object CameraConfig {
         def copyWithPrivacy(): CameraInfo = this.copy(password = "redacted", modules = modules.map(_.copyWithPrivacy()))
     }
 
-    case class OnvifCameraModuleConfig(port: Int, monitorEvents: Boolean, preferWebhookSub: Boolean, debounceMotion: Boolean) extends CameraModuleConfig {
+    case class OnvifCameraModuleConfig(port: Int, monitorEvents: Boolean, preferWebhookSub: Boolean,
+                                       debounceMotion: Boolean, forceDebounceDuration: Option[FiniteDuration]) extends CameraModuleConfig {
         override val moduleId: String = OnvifModule.moduleId
 
         override type ModConf = OnvifCameraModuleConfig

--- a/src/main/scala/camera/modules/onvif/OnvifModule.scala
+++ b/src/main/scala/camera/modules/onvif/OnvifModule.scala
@@ -1,24 +1,19 @@
 package net.bfgnet.cam2mqtt
 package camera.modules.onvif
 
-import camera.CameraActionProtocol
 import camera.CameraConfig.{CameraInfo, CameraModuleConfig, OnvifCameraModuleConfig}
 import camera.CameraProtocol._
-import camera.modules.onvif.OnvifSubProtocol.{OnvifSubCmd, TerminateSubscription, WebhookNotification}
+import camera.modules.onvif.subscription.OnvifSubProtocol.{OnvifSubCmd, TerminateSubscription, WebhookNotification}
+import camera.modules.onvif.subscription.{OnvifPullPointSub, OnvifWebhookSub}
 import camera.modules.{CameraModule, MqttCameraModule}
 import config.ConfigManager
 import eventbus.CameraEventBus
 import onvif.OnvifGetPropertiesRequests.OnvifCapabilitiesResponse
-import onvif.OnvifRequests
 import utils.ActorContextImplicits
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.Cancellable
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, Behavior, PostStop, Terminated}
-import akka.stream.alpakka.mqtt.MqttMessage
-import akka.util.ByteString
-
-import scala.collection.mutable
-import scala.util.{Failure, Success}
 
 sealed trait OnvifModuleCmd
 
@@ -26,7 +21,7 @@ case class OnvifCapabilities(resp: OnvifCapabilitiesResponse) extends OnvifModul
 
 case class OnvifError(error: Throwable) extends OnvifModuleCmd
 
-object OnvifModule extends CameraModule with MqttCameraModule with ActorContextImplicits {
+object OnvifModule extends CameraModule with OnvifModuleUtils with MqttCameraModule with ActorContextImplicits {
     override val moduleId: String = "onvif"
 
     override def createBehavior(camera: ActorRef[CameraCmd], info: CameraInfo, config: CameraModuleConfig): Behavior[CameraCmd] =
@@ -54,7 +49,7 @@ object OnvifModule extends CameraModule with MqttCameraModule with ActorContextI
                         context.watch(a)
                         a
                     }
-                    started(parent, camera, config, subActor, motion = false)
+                    started(parent, camera, config, subActor, motion = false, None)
                 case WrappedModuleCmd(OnvifError(err)) =>
                     throw err
                 case TerminateCam =>
@@ -114,50 +109,4 @@ object OnvifModule extends CameraModule with MqttCameraModule with ActorContextI
                     Behaviors.stopped
                 }
         }
-
-    private def getOnvifCapabilities(camera: CameraInfo, config: OnvifCameraModuleConfig)(implicit _ac: ActorContext[CameraCmd]) = {
-        _ac.pipeToSelf(OnvifRequests.getCapabilities(camera.host, config.port, camera.username, camera.password)) {
-            case Success(r) => WrappedModuleCmd(OnvifCapabilities(r))
-            case Failure(ex) => WrappedModuleCmd(OnvifError(ex))
-        }
-    }
-
-    override def loadConfiguration(from: Map[String, Any]): CameraModuleConfig = {
-        import utils.ConfigParserUtils._
-        val port = from.getInt("port").getOrElse(8000)
-        val monitorEvs = from.getBool("monitor_events")
-        val preferWebhook = from.getBool("prefer_webhook_subscription")
-        val debounceMotion = from.getBool("motion_debounce").orTrue
-        OnvifCameraModuleConfig(port, monitorEvs.orFalse, preferWebhook.orFalse, debounceMotion)
-    }
-
-    override def parseMQTTCommand(path: List[String], stringData: String): Option[CameraActionProtocol.CameraActionRequest] = None
-
-    override def eventToMqttMessage(ev: CameraEvent): Option[MqttMessage] = ev match {
-        case CameraMotionEvent(cameraId, moduleId, motion) =>
-            val value = if (motion) "on" else "off"
-            Some(MqttMessage(s"${cameraEventModulePath(cameraId, moduleId)}/motion", ByteString(value)))
-        case CameraObjectDetectionEvent(cameraId, moduleId, objectClass, detection) =>
-            val value = if (detection) "on" else "off"
-            Some(MqttMessage(s"${cameraEventModulePath(cameraId, moduleId)}/object/$objectClass/detected", ByteString(value)))
-        case CameraVisitorEvent(cameraId, moduleId, detection) =>
-            val value = if (detection) "on" else "off"
-            Some(MqttMessage(s"${cameraEventModulePath(cameraId, moduleId)}/visitor", ByteString(value)))
-        case _ => None
-    }
-
-    private def logCapabilities(cameraId: String, caps: OnvifCapabilitiesResponse)(implicit _ac: ActorContext[_]) = {
-        val c = new mutable.StringBuilder()
-        c ++= s"ONVIF Capabilities for camera $cameraId:\n"
-        if (caps.hasEvents) {
-            c ++= s"Events: ${caps.hasEvents}\n"
-        }
-        if (caps.hasPullPointSupport) {
-            c ++= s"Pull-Point subscription: ${caps.hasPullPointSupport}\n"
-        }
-        if (caps.hasPTZ) {
-            c ++= s"PTZ: ${caps.hasPTZ}\n"
-        }
-        _ac.log.info(c.toString().trim)
-    }
 }

--- a/src/main/scala/camera/modules/onvif/OnvifModuleUtils.scala
+++ b/src/main/scala/camera/modules/onvif/OnvifModuleUtils.scala
@@ -1,0 +1,73 @@
+package net.bfgnet.cam2mqtt
+package camera.modules.onvif
+
+import camera.CameraActionProtocol
+import camera.CameraConfig.{CameraInfo, CameraModuleConfig, OnvifCameraModuleConfig}
+import camera.CameraProtocol._
+import camera.modules.{CameraModule, MqttCameraModule}
+import onvif.OnvifGetPropertiesRequests.OnvifCapabilitiesResponse
+import onvif.OnvifRequests
+import utils.ActorContextImplicits
+
+import akka.actor.typed.scaladsl.ActorContext
+import akka.stream.alpakka.mqtt.MqttMessage
+import akka.util.ByteString
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.{Failure, Success}
+
+trait OnvifModuleUtils extends CameraModule with MqttCameraModule with ActorContextImplicits {
+
+    protected def getOnvifCapabilities(camera: CameraInfo, config: OnvifCameraModuleConfig)(implicit _ac: ActorContext[CameraCmd]) = {
+        _ac.pipeToSelf(OnvifRequests.getCapabilities(camera.host, config.port, camera.username, camera.password)) {
+            case Success(r) => WrappedModuleCmd(OnvifCapabilities(r))
+            case Failure(ex) => WrappedModuleCmd(OnvifError(ex))
+        }
+    }
+
+    override def loadConfiguration(from: Map[String, Any]): CameraModuleConfig = {
+        import utils.ConfigParserUtils._
+        val port = from.getInt("port").getOrElse(8000)
+        val monitorEvs = from.getBool("monitor_events")
+        val preferWebhook = from.getBool("prefer_webhook_subscription")
+        val debounceMotion = from.getBool("motion_debounce").orTrue
+        val forceDebounceTime = from.getDuration("force_motion_debounce_time").map(toFiniteDuration).filter(_.toMillis > 0)
+        OnvifCameraModuleConfig(port, monitorEvs.orFalse, preferWebhook.orFalse, debounceMotion, forceDebounceTime)
+    }
+
+    override def parseMQTTCommand(path: List[String], stringData: String): Option[CameraActionProtocol.CameraActionRequest] = None
+
+    override def eventToMqttMessage(ev: CameraEvent): Option[MqttMessage] = ev match {
+        case CameraMotionEvent(cameraId, moduleId, motion) =>
+            val value = if (motion) "on" else "off"
+            Some(MqttMessage(s"${cameraEventModulePath(cameraId, moduleId)}/motion", ByteString(value)))
+        case CameraObjectDetectionEvent(cameraId, moduleId, objectClass, detection) =>
+            val value = if (detection) "on" else "off"
+            Some(MqttMessage(s"${cameraEventModulePath(cameraId, moduleId)}/object/$objectClass/detected", ByteString(value)))
+        case CameraVisitorEvent(cameraId, moduleId, detection) =>
+            val value = if (detection) "on" else "off"
+            Some(MqttMessage(s"${cameraEventModulePath(cameraId, moduleId)}/visitor", ByteString(value)))
+        case _ => None
+    }
+
+    protected def logCapabilities(cameraId: String, caps: OnvifCapabilitiesResponse)(implicit _ac: ActorContext[_]) = {
+        val c = new mutable.StringBuilder()
+        c ++= s"ONVIF Capabilities for camera $cameraId:\n"
+        if (caps.hasEvents) {
+            c ++= s"Events: ${caps.hasEvents}\n"
+        }
+        if (caps.hasPullPointSupport) {
+            c ++= s"Pull-Point subscription: ${caps.hasPullPointSupport}\n"
+        }
+        if (caps.hasPTZ) {
+            c ++= s"PTZ: ${caps.hasPTZ}\n"
+        }
+        _ac.log.info(c.toString().trim)
+    }
+
+    protected def toFiniteDuration(d: Duration): FiniteDuration =
+        FiniteDuration(d.toMillis, TimeUnit.MILLISECONDS)
+
+}

--- a/src/main/scala/camera/modules/onvif/subscription/OnvifMessageParser.scala
+++ b/src/main/scala/camera/modules/onvif/subscription/OnvifMessageParser.scala
@@ -1,7 +1,8 @@
 package net.bfgnet.cam2mqtt
-package camera.modules.onvif
+package camera.modules.onvif.subscription
 
 import camera.CameraProtocol.{CameraEvent, CameraMotionEvent, CameraObjectDetectionEvent, CameraVisitorEvent}
+import camera.modules.onvif.OnvifModule
 
 import akka.actor.typed.scaladsl.ActorContext
 import org.jsoup.Jsoup

--- a/src/main/scala/camera/modules/onvif/subscription/OnvifPullPointSub.scala
+++ b/src/main/scala/camera/modules/onvif/subscription/OnvifPullPointSub.scala
@@ -1,9 +1,10 @@
 package net.bfgnet.cam2mqtt
-package camera.modules.onvif
+package camera.modules.onvif.subscription
 
 import camera.CameraConfig.{CameraInfo, OnvifCameraModuleConfig}
 import camera.CameraProtocol._
-import camera.modules.onvif.OnvifSubProtocol._
+import camera.modules.onvif.OnvifModule
+import OnvifSubProtocol._
 import onvif.OnvifRequests
 import onvif.OnvifSubscriptionRequests.SubscriptionInfo
 import utils.ActorContextImplicits

--- a/src/main/scala/camera/modules/onvif/subscription/OnvifSubProtocol.scala
+++ b/src/main/scala/camera/modules/onvif/subscription/OnvifSubProtocol.scala
@@ -1,5 +1,5 @@
 package net.bfgnet.cam2mqtt
-package camera.modules.onvif
+package camera.modules.onvif.subscription
 
 import camera.CameraProtocol.CameraEvent
 import onvif.OnvifSubscriptionRequests.SubscriptionInfo

--- a/src/main/scala/camera/modules/onvif/subscription/OnvifWebhookSub.scala
+++ b/src/main/scala/camera/modules/onvif/subscription/OnvifWebhookSub.scala
@@ -1,9 +1,10 @@
 package net.bfgnet.cam2mqtt
-package camera.modules.onvif
+package camera.modules.onvif.subscription
 
 import camera.CameraConfig.{CameraInfo, OnvifCameraModuleConfig}
 import camera.CameraProtocol._
-import camera.modules.onvif.OnvifSubProtocol._
+import camera.modules.onvif.OnvifModule
+import OnvifSubProtocol._
 import config.WebhookConfig
 import onvif.OnvifRequests
 import onvif.OnvifSubscriptionRequests.SubscriptionInfo

--- a/src/main/scala/utils/ConfigParserUtils.scala
+++ b/src/main/scala/utils/ConfigParserUtils.scala
@@ -1,6 +1,7 @@
 package net.bfgnet.cam2mqtt
 package utils
 
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 object ConfigParserUtils {
@@ -12,9 +13,11 @@ object ConfigParserUtils {
         def getString(key: String): Option[String] =
             Try(from.get(key)).toOption.flatten.filter(_ != null).map(_.toString).filter(_.nonEmpty)
 
-        def getInt(key: String): Option[Int] = {
+        def getInt(key: String): Option[Int] =
             Try(from.get(key)).toOption.flatten.filter(_ != null).flatMap(v => Try(v.toString.toInt).toOption)
-        }
+
+        def getDuration(key: String): Option[Duration] =
+            Try(from.get(key)).toOption.flatten.filter(_ != null).flatMap(v => Try(Duration(v.toString)).toOption)
     }
 
     implicit class BooleanOptionExt(from: Option[Boolean]) {


### PR DESCRIPTION
This new option `force_motion_debounce_time` allows to fix problems with motion events on cameras like Reolink E1 Zoom and RLC-410W.