### PR TITLE
Implement privacy mask for Reolink cameras

### DIFF
--- a/MQTT.md
+++ b/MQTT.md
@@ -28,6 +28,7 @@
     cam2mqtt/camera/{cameraId}/state/reolink/audio/volume 0-100
     cam2mqtt/camera/{cameraId}/state/reolink/spotlight/state on/off
     cam2mqtt/camera/{cameraId}/state/reolink/spotlight/brightness 0-100
+    cam2mqtt/camera/{cameraId}/state/reolink/privacy_mask on/off
 
 ##### Commands
     cam2mqtt/camera/{cameraId}/command/reolink/nightvision auto/on/off
@@ -41,6 +42,7 @@
     cam2mqtt/camera/{cameraId}/command/reolink/alarm/play on/off/1-100
     cam2mqtt/camera/{cameraId}/command/reolink/spotlight/state on/off
     cam2mqtt/camera/{cameraId}/command/reolink/spotlight/brightness 0-100
+    cam2mqtt/camera/{cameraId}/command/reolink/privacy_mask on/off
 
 
 ##### Motion events (AI detection)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For now, only two modules are implemented:
     * Turn on/off spotlight and change brightness
     * Change audio volume
     * Play alarm
+    * Enable/disable fullscreen privacy mask
   * AI powered object detection
     * Person detection
     * Vehicle detection

--- a/src/main/scala/camera/Protocol.scala
+++ b/src/main/scala/camera/Protocol.scala
@@ -102,6 +102,9 @@ object CameraActionProtocol {
 
     case class PlayAlarmActionRequest(play: Boolean, times: Option[Int], override val replyTo: Option[ActorRef[CameraActionResponse]]) extends CameraActionRequest
 
+    // Privacy mask
+    case class SetPrivacyMaskActionRequest(enabled: Boolean, override val replyTo: Option[ActorRef[CameraActionResponse]]) extends CameraActionRequest
+
 }
 
 object CameraConfig {

--- a/src/main/scala/reolink/ReolinkCapabilityRequest.scala
+++ b/src/main/scala/reolink/ReolinkCapabilityRequest.scala
@@ -230,7 +230,7 @@ trait ReolinkCapabilityRequest extends ReolinkRequest {
     }
 
     private def isFullscreenPrivacyMask(area: List[MaskArea]): Boolean = {
-        area.exists { mask =>
+        area != null && area.exists { mask =>
             mask.block.x == 0 && mask.block.y == 0 &&
                 mask.block.height == mask.screen.height && mask.block.width == mask.screen.width
         }

--- a/src/main/scala/reolink/ReolinkCommands.scala
+++ b/src/main/scala/reolink/ReolinkCommands.scala
@@ -105,6 +105,17 @@ case class GetAiStateParams(channel: Int, dog_cat: GetAiObjectState, face: GetAi
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class GetAiStateCmdResponse(cmd: String, code: Int, value: GetAiStateParams)
 
+// Get/Set Privacy mask
+case class MaskAreaBlock(height: Int, width: Int, x: Int, y: Int)
+
+case class MaskAreaScreen(height: Int, width: Int)
+
+case class MaskArea(block: MaskAreaBlock, screen: MaskAreaScreen)
+
+case class SetMaskCommandParams(channel: Int, area: List[MaskArea], enable: Int)
+
+case class SetMaskCommand(Mask: SetMaskCommandParams) extends CommandParams
+
 // Common
 case class Channel(channel: Int) extends CommandParams
 
@@ -337,6 +348,19 @@ trait ReolinkCommands extends ReolinkRequest {
         reqPost(host, Option(cmd.cmd), OM.writeValueAsString(List(cmd))).map {
             r => parseCommandResponse(r)
         }
+    }
+
+    def setPrivacyMask(host: ReolinkHost, mask: List[MaskArea])
+                      (implicit _as: ClassicActorSystemProvider, _ec: ExecutionContext): Future[ReolinkCmdResponse] = {
+        val cmd = ReolinkCmd("SetMask", 0, SetMaskCommand(SetMaskCommandParams(0, mask, 1)))
+        reqPost(host, Option(cmd.cmd), OM.writeValueAsString(List(cmd))).map {
+            r => parseCommandResponse(r)
+        }
+    }
+
+    def fullScreenPrivacyMask(): List[MaskArea] = {
+        val area = MaskArea(MaskAreaBlock(100, 100, 0, 0), MaskAreaScreen(100, 100))
+        List(area)
     }
 
     private def postpone[T](duration: FiniteDuration)(code: => Future[T])(implicit _ec: ExecutionContext, _sch: Scheduler): Future[T] = {


### PR DESCRIPTION
When enabled, the camera video stream will be just a black screen.
### Use case:
When enabled, the privacy mask will turn the screen black to keep privacy when an alarm system is disarmed, and work normally when the alarm system is armed. Useful for indoor cameras.